### PR TITLE
fix: use project config values instead of hardcoded text

### DIFF
--- a/apps/web/app/(web)/landing/page.tsx
+++ b/apps/web/app/(web)/landing/page.tsx
@@ -3,10 +3,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { CheckCircle, Palette, Globe, Shield, Zap, Code, Database, Smartphone } from 'lucide-react'
-import { getGithubUrl } from '@boilerplate/config/project.config'
+import { getGithubUrl, getDisplayName, getDescription } from '@boilerplate/config/project.config'
 
 export default function LandingPage() {
   const githubUrl = getGithubUrl()
+  const projectName = getDisplayName()
+  const projectDescription = getDescription()
   
   return (
     <div>
@@ -32,12 +34,12 @@ export default function LandingPage() {
           <h1 className="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-bold tracking-tight text-foreground mb-6 leading-tight">
             Modern Web Application{" "}
             <span className="bg-gradient-to-r from-primary to-primary/60 bg-clip-text text-transparent">
-              Boilerplate
+              {projectName}
             </span>
           </h1>
           
           <p className="text-xl sm:text-2xl text-muted-foreground mb-8 max-w-3xl mx-auto leading-relaxed">
-            A production-ready Next.js boilerplate with authentication, theming, internationalization, and modern development tools.{" "}
+            {projectDescription}{" "}
             <span className="text-foreground font-medium">Build faster, deploy easier.</span>
           </p>
           

--- a/apps/web/app/components/sidebar.tsx
+++ b/apps/web/app/components/sidebar.tsx
@@ -7,6 +7,7 @@ import { GalleryVerticalEnd, Home, Settings } from "lucide-react"
 
 // Update import to use the consolidated file
 import { useLanguageSettings } from "@/hooks/use-settings-store"
+import { getDisplayName } from "@boilerplate/config/project.config"
 
 interface SidebarProps {
   version: string
@@ -59,7 +60,7 @@ export function Sidebar({ version }: SidebarProps) {
             <GalleryVerticalEnd className="size-5" />
           </div>
           <div className="flex flex-col gap-0.5 leading-none">
-            <span className="text-base font-semibold">Boilerplate</span>
+            <span className="text-base font-semibold">{getDisplayName()}</span>
             <span className="text-xs text-muted-foreground">v{version}</span>
           </div>
         </Link>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -7,7 +7,7 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { AppLayout } from "@/components/app-layout"
 // Import the correct provider
 import { SettingsStoreProvider } from "@/hooks/use-settings-store"
-import { getVersion } from "@boilerplate/config/project.config"
+import { getVersion, getDisplayName, getDescription } from "@boilerplate/config/project.config"
 import { InstallPrompt } from "@/components/pwa/install-prompt"
 import { OfflineIndicator } from "@/components/pwa/offline-indicator"
 import { NotificationProvider } from "@/hooks/use-notifications"
@@ -16,8 +16,8 @@ import { QueryProvider } from "@/providers/query-provider"
 const inter = Inter({ subsets: ["latin"] })
 
 export const metadata: Metadata = {
-  title: "Boilerplate App",
-  description: "Next.js boilerplate with sidebar, header, and content area",
+  title: `${getDisplayName()} App`,
+  description: getDescription(),
     generator: 'v0.dev'
 }
 


### PR DESCRIPTION
This PR fixes issue #26 by properly using project configuration values instead of hardcoded text throughout the application.

## Changes
- Updated sidebar to use `getDisplayName()` from project config
- Updated layout metadata to use project config for title and description
- Updated landing page to use dynamic project name and description
- Ensured proper separation between project identity (config) and translatable UI text (locales)

## Benefits
- True template behavior: run setup script to configure project branding
- Components automatically reflect project identity from config
- Clear separation between configurable values and translatable content
- No more scattered hardcoded project names

Generated with [Claude Code](https://claude.ai/code)